### PR TITLE
Fix `download` to fetch file contents (remove `DIRLISTONLY`, use `escapepath`)

### DIFF
--- a/src/SFTPImpl.jl
+++ b/src/SFTPImpl.jl
@@ -636,9 +636,13 @@ function download(
         output = joinpath(abspath(downloadDir), file_name)
     end
 
+    # Use escapepath (not escapeuri) to preserve '/' in multi-segment paths
+    uri = resolvereference(sftp.uri, escapepath(file_name))
 
-    uri = resolvereference(sftp.uri, escapeuri(file_name))
-
+    # Override easy_hook to remove CURLOPT_DIRLISTONLY (set by reset_easy_hook for readdir)
+    sftp.downloader.easy_hook = (easy, info) -> begin
+        setStandardOptions(sftp, easy, info)
+    end
 
     try
 
@@ -647,6 +651,8 @@ function download(
     catch e
 
         rethrow()
+    finally
+        reset_easy_hook(sftp)
     end
     return output
 end

--- a/src/SFTPImpl.jl
+++ b/src/SFTPImpl.jl
@@ -8,24 +8,24 @@ using Dates
 mutable struct SFTP
     downloader::Downloader
     uri::URI
-    username::Union{String, Nothing}
-    password::Union{String, Nothing}
+    username::Union{String,Nothing}
+    password::Union{String,Nothing}
     disable_verify_peer::Bool
     disable_verify_host::Bool
     verbose::Bool
-    public_key_file::Union{String, Nothing}
-    private_key_file::Union{String, Nothing}
+    public_key_file::Union{String,Nothing}
+    private_key_file::Union{String,Nothing}
 
 end
 
 struct SFTPStatStruct
     desc::String
-    mode    :: UInt
-    nlink   :: Int
-    uid     :: String
-    gid     :: String
-    size    :: Int64
-    mtime   :: Float64
+    mode::UInt
+    nlink::Int
+    uid::String
+    gid::String
+    size::Int64
+    mtime::Float64
 end
 
 function check_and_create_fingerprint(hostNameOrIP::AbstractString)
@@ -34,17 +34,17 @@ function check_and_create_fingerprint(hostNameOrIP::AbstractString)
     try
 
         known_hosts_file = joinpath(dir, ".ssh", "known_hosts")
-     
-        rows=CSV.File(known_hosts_file;delim=" ",types=String,header=false)
+
+        rows = CSV.File(known_hosts_file; delim=" ", types=String, header=false)
         for row in rows
             row[1] != hostNameOrIP && continue
-            
+
             println("Found host in known_hosts")
             # check the entry we found
 
             fingerprintAlgo = row[2]
             #These are known to work
-            (fingerprintAlgo == "ecdsa-sha2-nistp256" || fingerprintAlgo == "ecdsa-sha2-nistp256" || fingerprintAlgo ==  "ecdsa-sha2-nistp521"  || fingerprintAlgo == "ssh-rsa" ) && return
+            (fingerprintAlgo == "ecdsa-sha2-nistp256" || fingerprintAlgo == "ecdsa-sha2-nistp256" || fingerprintAlgo == "ecdsa-sha2-nistp521" || fingerprintAlgo == "ssh-rsa") && return
             println("Warning: Correct fingerprint not found in known_hosts")
         end
 
@@ -64,24 +64,24 @@ end
 
 
 function Base.show(io::IO, sftp::SFTP)
- 
+
     join(io, [
-        "URL:       $(sftp.uri)",
-        "Username:  $(sftp.username)",
-    ], "\n")
+            "URL:       $(sftp.uri)",
+            "Username:  $(sftp.username)",
+        ], "\n")
 end
 
 function create_fingerprint(hostNameOrIP::AbstractString)
-    
+
 
     dir = homedir()
 
     sshdir = joinpath(dir, ".ssh")
-    !isdir( sshdir) && mkdir(sshdir)
+    !isdir(sshdir) && mkdir(sshdir)
 
     known_hosts = joinpath(dir, ".ssh", "known_hosts")
     keyscan = ""
-    try 
+    try
         keyscan = readchomp(`ssh-keyscan -t ssh-rsa $(hostNameOrIP)`)
     catch e
         println("Keyscan failed. Check if ssh-keyscan is installed")
@@ -108,10 +108,10 @@ end
  Creates a new SFTP client using certificate authentication, and keys in the files specified
 
   sftp = SFTP("sftp://mysitewhereIhaveACertificate.com", "myuser", "test.pub", "test.pem")
-  
+
 
 """
-function SFTP(url::AbstractString, username::AbstractString, public_key_file::AbstractString, private_key_file::AbstractString;disable_verify_peer=false, disable_verify_host=false, verbose=false)
+function SFTP(url::AbstractString, username::AbstractString, public_key_file::AbstractString, private_key_file::AbstractString; disable_verify_peer=false, disable_verify_host=false, verbose=false)
     downloader = Downloads.Downloader()
 
     uri = URI(url)
@@ -127,23 +127,23 @@ end
 
 """
     SFTP(url::AbstractString, username::AbstractString;disable_verify_peer=false, disable_verify_host=false)
- 
- Creates a new SFTP client using certificate authentication. 
+
+ Creates a new SFTP client using certificate authentication.
 
   sftp = SFTP("sftp://mysitewhereIhaveACertificate.com", "myuser")
-  
-  Note! You must provide the username for this to work. 
+
+  Note! You must provide the username for this to work.
 
   Before using this method, you must set up your certificates in ~/.ssh/id_rsa and ~/.ssh/id_rsa.pub
 
-  Of course, the host need to be in the known_hosts file as well. 
+  Of course, the host need to be in the known_hosts file as well.
 
   Test using your local client first: ssh myuser@mysitewhereIhaveACertificate.com
 
   See other method if you want to use files not in ~/ssh/
 
 """
-function SFTP(url::AbstractString, username::AbstractString;disable_verify_peer=false, disable_verify_host=false, verbose=false)
+function SFTP(url::AbstractString, username::AbstractString; disable_verify_peer=false, disable_verify_host=false, verbose=false)
     downloader = Downloads.Downloader()
 
     uri = URI(url)
@@ -170,7 +170,7 @@ sftp = SFTP("sftp://test.rebex.net", "demo", "password")
 
 
 """
-function SFTP(url::AbstractString, username::AbstractString, password::AbstractString;create_known_hosts_entry=true, disable_verify_peer=false, disable_verify_host=false, verbose=false)
+function SFTP(url::AbstractString, username::AbstractString, password::AbstractString; create_known_hosts_entry=true, disable_verify_peer=false, disable_verify_host=false, verbose=false)
     downloader = Downloads.Downloader()
 
     uri = URI(url)
@@ -187,11 +187,11 @@ end
 
 function slashEnd(sftp)
     path = sftp.uri.path
-    if !endswith(path, "/") 
+    if !endswith(path, "/")
         path = path * "/"
     end
     newUrl = resolvereference(sftp.uri, escapepath(path))
-        
+
     sftp.uri = newUrl
 
 end
@@ -205,18 +205,18 @@ function setStandardOptions(sftp, easy, info)
     end
 
     if sftp.disable_verify_host
-    
-        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYHOST , 0)
+
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYHOST, 0)
     end
 
     if sftp.disable_verify_peer
-    
-        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER , 1)
+
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER, 1)
     end
 
- 
+
     if sftp.public_key_file != nothing
-     Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSH_PUBLIC_KEYFILE, sftp.public_key_file)
+        Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSH_PUBLIC_KEYFILE, sftp.public_key_file)
     end
 
     if sftp.private_key_file != nothing
@@ -229,24 +229,24 @@ function setStandardOptions(sftp, easy, info)
 
 end
 
-function reset_easy_hook(sftp::SFTP) 
-        
-        downloader = sftp.downloader
-        
+function reset_easy_hook(sftp::SFTP)
 
-        downloader.easy_hook = (easy, info) -> begin
+    downloader = sftp.downloader
+
+
+    downloader.easy_hook = (easy, info) -> begin
         setStandardOptions(sftp, easy, info)
         Downloads.Curl.setopt(easy, CURLOPT_DIRLISTONLY, 1)
 
 
-        
-        
+
+
     end
 end
 
 
 function sftpescapepath(path::String)
-    
+
     return escapepath(path)
 end
 
@@ -265,13 +265,13 @@ end
 
 function ftp_command(sftp::SFTP, command::String)
     slist = Ptr{Cvoid}(0)
-  
+
     slist = curl_slist_append(slist, command)
 
     sftp.downloader.easy_hook = (easy, info) -> begin
         setStandardOptions(sftp, easy, info)
-  
-        Downloads.Curl.setopt(easy,  CURLOPT_QUOTE, slist)
+
+        Downloads.Curl.setopt(easy, CURLOPT_QUOTE, slist)
     end
 
     uri = string(sftp.uri)
@@ -280,8 +280,8 @@ function ftp_command(sftp::SFTP, command::String)
 
     try
         output = Downloads.download(uri, io; sftp.downloader)
-        
-    finally 
+
+    finally
         curl_slist_free_all(slist)
         reset_easy_hook(sftp)
     end
@@ -291,17 +291,17 @@ function ftp_command(sftp::SFTP, command::String)
 end
 
 function sftpstat2(sftp, dir::String)
-    
+
     stats = sftpstat(sftp, dir)
-    a = filter(x->x.desc != "." && x.desc != "..",stats )
-    return a;
+    a = filter(x -> x.desc != "." && x.desc != "..", stats)
+    return a
 end
 
 function myjoinpath(path::AbstractString, name::AbstractString)
     path == "." && return name
     #println("path $path")
     #println("name $name")
-    path*"/" * name * "/"
+    path * "/" * name * "/"
 
 end
 
@@ -311,7 +311,7 @@ end
     Return an iterator that walks the directory tree of a directory.
     The iterator returns a tuple containing `(rootpath, dirs, files)`.
 
-    
+
     # Examples
     ```julia
     for (root, dirs, files) in walkdir(sftp, ".")
@@ -329,8 +329,9 @@ end
 """
 function walkdir(sftp::SFTP, root; topdown=true, follow_symlinks=false, onerror=throw)
     function _walkdir(chnl, root)
-   
-        tryf2( f, sftp, p) = try
+
+        tryf2(f, sftp, p) =
+            try
                 f(sftp, p)
             catch err
                 show(err)
@@ -343,7 +344,8 @@ function walkdir(sftp::SFTP, root; topdown=true, follow_symlinks=false, onerror=
                 return
             end
 
-            tryf( f, p) = try
+        tryf(f, p) =
+            try
                 f(p)
             catch err
                 show(err)
@@ -351,26 +353,26 @@ function walkdir(sftp::SFTP, root; topdown=true, follow_symlinks=false, onerror=
                 try
                     onerror(err)
                 catch err2
-                    
+
                     close(chnl, err2)
                 end
                 return
             end
 
-        content = tryf2(sftpstat2, sftp , root)
+        content = tryf2(sftpstat2, sftp, root)
 
         content === nothing && return
         dirs = Vector{String}()
         files = Vector{String}()
         for statstruct in content
- 
+
             name = statstruct.desc
-           
+
             path = myjoinpath(root, name)
-            
-   
+
+
             isadir = tryf(isdir, statstruct)
-      
+
 
             # If we're not following symlinks, then treat all symlinks as files
             if (!follow_symlinks && something(tryf(islink, statstruct), true)) || !something(tryf(isdir, statstruct), false)
@@ -411,32 +413,32 @@ Base.islink(st::SFTPStatStruct) = filemode(st) & 0xf000 == 0xa000
 
 
 """
-    Base.isdir(st::SFTPStatStruct) 
+    Base.isdir(st::SFTPStatStruct)
 
 Test if st is a directory
 """
 Base.isdir(st::SFTPStatStruct) = filemode(st) & 0xf000 == 0x4000
 
 """
-    Base.isfile(st::SFTPStatStruct) 
+    Base.isfile(st::SFTPStatStruct)
 
 Test if st is a file
 """
 Base.isfile(st::SFTPStatStruct) = filemode(st) & 0xf000 == 0x8000
 
 """
-    Base.isdir(st::SFTPStatStruct) 
+    Base.isdir(st::SFTPStatStruct)
 
 Get the filemode of the directory
 """
 Base.filemode(st::SFTPStatStruct) = st.mode
 
 function parseDate(monthPart::String, dayPart::String, yearOrTimePart::String)
-     yearStr::String = occursin(":",yearOrTimePart) ? string(year(now())) : yearOrTimePart
-     timeStr::String = !occursin(":",yearOrTimePart) ? "00:00" : yearOrTimePart
+    yearStr::String = occursin(":", yearOrTimePart) ? string(year(now())) : yearOrTimePart
+    timeStr::String = !occursin(":", yearOrTimePart) ? "00:00" : yearOrTimePart
 
-     dateTime = DateTime("$monthPart $dayPart $yearStr $timeStr",dateformat"u d yyyy H:M ")
- 
+    dateTime = DateTime("$monthPart $dayPart $yearStr $timeStr", dateformat"u d yyyy H:M ")
+
     return datetime2unix(dateTime)
 end
 
@@ -456,10 +458,10 @@ function parseMode(s::String)::UInt
 end
 
 function strToNumber(s::String)::Int64
-    b1 = (s[1] != '-') ?  4 : 0
-    b2 = (s[2] != '-') ?  2 : 0
-    b3 = (s[3] != '-') ?  1 : 0
-    return b1+b2+b3
+    b1 = (s[1] != '-') ? 4 : 0
+    b2 = (s[2] != '-') ? 2 : 0
+    b3 = (s[3] != '-') ? 1 : 0
+    return b1 + b2 + b3
 end
 
 function parseStat(s::String)
@@ -473,13 +475,13 @@ function parseStat(s::String)
     stringLength = length(s)
 
     i = 1
-    
+
     while (i < stringLength)
         c = s[i]
         if c == ' '
             resultVec[parseCounter] = s[lastIndex:i-1]
             parseCounter += 1
-            
+
             while (i < stringLength && c == ' ')
                 i += 1
                 c = s[i]
@@ -487,7 +489,7 @@ function parseStat(s::String)
 
             lastIndex = i
 
-            if parseCounter == 9 
+            if parseCounter == 9
                 resultVec[parseCounter] = s[lastIndex:end]
                 break
             end
@@ -497,14 +499,14 @@ function parseStat(s::String)
         i += 1
     end
     return resultVec
-    
+
 end
 
 
 
 
 function makeStruct(stats::Vector{String})::SFTPStatStruct
-    SFTPStatStruct(stats[9], parseMode(stats[1]),  parse(Int64, stats[2]), stats[3], stats[4], parse(Int64, stats[5]), parseDate(stats[6], stats[7], stats[8]))  
+    SFTPStatStruct(stats[9], parseMode(stats[1]), parse(Int64, stats[2]), stats[3], stats[4], parse(Int64, stats[5]), parseDate(stats[6], stats[7], stats[8]))
 end
 
 """
@@ -539,16 +541,16 @@ function sftpstat(sftp::SFTP, path::AbstractString)
             path = path * "/"
         end
 
-        newUrl = resolvereference(sftp.uri,sftpescapepath(path))
+        newUrl = resolvereference(sftp.uri, sftpescapepath(path))
 
 
-        io = IOBuffer();
+        io = IOBuffer()
 
         try
             output = Downloads.download(string(newUrl), io; sftp.downloader)
-            
-            
-        finally 
+
+
+        finally
             reset_easy_hook(sftp)
         end
 
@@ -557,8 +559,8 @@ function sftpstat(sftp::SFTP, path::AbstractString)
         res = String(take!(io))
         io2 = IOBuffer(res)
 
-        stats = readlines(io2;keep=false)
-        
+        stats = readlines(io2; keep=false)
+
         return makeStruct.(parseStat.(stats))
         #return files
     catch e
@@ -574,7 +576,7 @@ end
 """
     upload(sftp::SFTP, file_name::AbstractString)
 
-Upload (put) a file to the server. Broadcasting can be used too. 
+Upload (put) a file to the server. Broadcasting can be used too.
 
 files=readdir()
 upload.(sftp,files)
@@ -583,18 +585,18 @@ upload.(sftp,files)
 function upload(sftp::SFTP,
     file_name::AbstractString)
 
-       
-        open(file_name, "r") do local_file
+
+    open(file_name, "r") do local_file
 
 
-            file = escapeuri(basename(file_name))
+        file = escapeuri(basename(file_name))
 
-            uri = resolvereference(sftp.uri, file)
+        uri = resolvereference(sftp.uri, file)
 
-            output = Downloads.request(string(uri), input=local_file;downloader=sftp.downloader)
-        end
+        output = Downloads.request(string(uri), input=local_file; downloader=sftp.downloader)
+    end
 
-        return nothing
+    return nothing
 end
 
 
@@ -605,7 +607,7 @@ end
     file_name::AbstractString,
      output = tempname();downloadDir::Union{String, Nothing}=nothing)
 
-     Download a file. You can download it and use it directly, or save it to a file. 
+     Download a file. You can download it and use it directly, or save it to a file.
      Specify downloadDir if you want to save downloaded files. You can also use broadcasting.
     Example:
 
@@ -618,32 +620,32 @@ end
     df=DataFrame(CSV.File(SFTPClient.download(sftp, "/mydir/test.csv")))
 
 
-     
+
 """
 function download(
     sftp::SFTP,
     file_name::AbstractString,
-     output = tempname();downloadDir::Union{String, Nothing}=nothing)
+    output=tempname(); downloadDir::Union{String,Nothing}=nothing)
 
-    
-     if file_name == "." || file_name == ".."
+
+    if file_name == "." || file_name == ".."
         return
-     end
+    end
 
-     if downloadDir != nothing
+    if downloadDir != nothing
         output = joinpath(abspath(downloadDir), file_name)
-     end
+    end
 
-     
-     uri = resolvereference(sftp.uri, escapeuri(file_name))
+
+    uri = resolvereference(sftp.uri, escapeuri(file_name))
 
 
     try
-    
-       output = Downloads.download(string(uri), output; sftp.downloader)
+
+        output = Downloads.download(string(uri), output; sftp.downloader)
 
     catch e
-   
+
         rethrow()
     end
     return output
@@ -655,7 +657,7 @@ end
 Reads the current directory. Returns a vector of Strings just like the regular readdir function.
 
 """
-function Base.readdir(sftp::SFTP, join::Bool = false, sort::Bool = true)
+function Base.readdir(sftp::SFTP, join::Bool=false, sort::Bool=true)
     output = nothing
 
     try
@@ -668,9 +670,9 @@ function Base.readdir(sftp::SFTP, join::Bool = false, sort::Bool = true)
         #println("URI String $uriString")
 
         dir = sftp.uri.path
-    
 
-        io = IOBuffer();
+
+        io = IOBuffer()
 
         output = Downloads.download(uriString, io; sftp.downloader)
 
@@ -678,11 +680,11 @@ function Base.readdir(sftp::SFTP, join::Bool = false, sort::Bool = true)
         # Don't know why this is necessary
         res = String(take!(io))
         io2 = IOBuffer(res)
-        files = readlines(io2;keep=false)
+        files = readlines(io2; keep=false)
 
-        files = filter(x->x != "..", files)
-        
-        files = filter(x->x != ".", files)
+        files = filter(x -> x != "..", files)
+
+        files = filter(x -> x != ".", files)
 
 
         sort && sort!(files)
@@ -698,25 +700,25 @@ end
 
 """
     cd(sftp::SFTP, dir::AbstractString)
-    
-    Change the directory for the SFTP client. 
+
+    Change the directory for the SFTP client.
 
 """
 function Base.cd(sftp::SFTP, dir::AbstractString)
-    
+
     oldUrl = sftp.uri
 
     # If we fail, set back to the old url
     try
-    
+
         if !isdirpath(dir)
             dir = dir * "/"
         end
 
-        newUrl = resolvereference(oldUrl,sftpescapepath(dir))
+        newUrl = resolvereference(oldUrl, sftpescapepath(dir))
 
         #show(newUrl)
-       
+
         sftp.uri = newUrl
         #show(sftp.uri)
         readdir(sftp)
@@ -757,7 +759,7 @@ end
 
 """
 function Base.mkdir(sftp::SFTP, dir::AbstractString)
- 
+
     resp = ftp_command(sftp, "mkdir $(handleRelativePath(dir, sftp))")
     return nothing
 end
@@ -769,7 +771,7 @@ end
     new_name::AbstractString
     )
 
-Move, i.e., rename the file. 
+Move, i.e., rename the file.
 
 """
 function Base.mv(
@@ -781,7 +783,3 @@ function Base.mv(
     return nothing
 
 end
-
-
-
-

--- a/src/SFTPImpl.jl
+++ b/src/SFTPImpl.jl
@@ -15,7 +15,33 @@ mutable struct SFTP
     verbose::Bool
     public_key_file::Union{String,Nothing}
     private_key_file::Union{String,Nothing}
+    op_lock::ReentrantLock
 
+end
+
+function SFTP(
+    downloader::Downloader,
+    uri::URI,
+    username::Union{String,Nothing},
+    password::Union{String,Nothing},
+    disable_verify_peer::Bool,
+    disable_verify_host::Bool,
+    verbose::Bool,
+    public_key_file::Union{String,Nothing},
+    private_key_file::Union{String,Nothing}
+)
+    return SFTP(
+        downloader,
+        uri,
+        username,
+        password,
+        disable_verify_peer,
+        disable_verify_host,
+        verbose,
+        public_key_file,
+        private_key_file,
+        ReentrantLock()
+    )
 end
 
 struct SFTPStatStruct
@@ -229,6 +255,15 @@ function setStandardOptions(sftp, easy, info)
 
 end
 
+function with_sftp_lock(f::Function, sftp::SFTP)
+    lock(sftp.op_lock)
+    try
+        return f()
+    finally
+        unlock(sftp.op_lock)
+    end
+end
+
 function reset_easy_hook(sftp::SFTP)
 
     downloader = sftp.downloader
@@ -264,29 +299,31 @@ function handleRelativePath(fileName, sftp::SFTP)
 end
 
 function ftp_command(sftp::SFTP, command::String)
-    slist = Ptr{Cvoid}(0)
+    return with_sftp_lock(sftp) do
+        slist = Ptr{Cvoid}(0)
 
-    slist = curl_slist_append(slist, command)
+        slist = curl_slist_append(slist, command)
 
-    sftp.downloader.easy_hook = (easy, info) -> begin
-        setStandardOptions(sftp, easy, info)
+        sftp.downloader.easy_hook = (easy, info) -> begin
+            setStandardOptions(sftp, easy, info)
 
-        Downloads.Curl.setopt(easy, CURLOPT_QUOTE, slist)
+            Downloads.Curl.setopt(easy, CURLOPT_QUOTE, slist)
+        end
+
+        uri = string(sftp.uri)
+        io = IOBuffer()
+        output = nothing
+
+        try
+            output = Downloads.download(uri, io; sftp.downloader)
+
+        finally
+            curl_slist_free_all(slist)
+            reset_easy_hook(sftp)
+        end
+
+        return output
     end
-
-    uri = string(sftp.uri)
-    io = IOBuffer()
-    output = nothing
-
-    try
-        output = Downloads.download(uri, io; sftp.downloader)
-
-    finally
-        curl_slist_free_all(slist)
-        reset_easy_hook(sftp)
-    end
-
-    return output
 
 end
 
@@ -526,45 +563,45 @@ Like Julia stat, but returns a Vector of SFTPStatStructs. Note that you can only
 
 """
 function sftpstat(sftp::SFTP, path::AbstractString)
+    return with_sftp_lock(sftp) do
+        sftp.downloader.easy_hook = (easy, info) -> begin
+            setStandardOptions(sftp, easy, info)
 
-
-    sftp.downloader.easy_hook = (easy, info) -> begin
-        setStandardOptions(sftp, easy, info)
-
-    end
-
-    output = nothing
-
-    try
-
-        if !isdirpath(path)
-            path = path * "/"
         end
 
-        newUrl = resolvereference(sftp.uri, sftpescapepath(path))
-
-
-        io = IOBuffer()
+        output = nothing
 
         try
-            output = Downloads.download(string(newUrl), io; sftp.downloader)
+
+            if !isdirpath(path)
+                path = path * "/"
+            end
+
+            newUrl = resolvereference(sftp.uri, sftpescapepath(path))
 
 
-        finally
-            reset_easy_hook(sftp)
+            io = IOBuffer()
+
+            try
+                output = Downloads.download(string(newUrl), io; sftp.downloader)
+
+
+            finally
+                reset_easy_hook(sftp)
+            end
+
+
+            # Don't know why this is necessary
+            res = String(take!(io))
+            io2 = IOBuffer(res)
+
+            stats = readlines(io2; keep=false)
+
+            return makeStruct.(parseStat.(stats))
+            #return files
+        catch e
+            rethrow()
         end
-
-
-        # Don't know why this is necessary
-        res = String(take!(io))
-        io2 = IOBuffer(res)
-
-        stats = readlines(io2; keep=false)
-
-        return makeStruct.(parseStat.(stats))
-        #return files
-    catch e
-        rethrow()
     end
 
 
@@ -584,19 +621,19 @@ upload.(sftp,files)
 """
 function upload(sftp::SFTP,
     file_name::AbstractString)
+    return with_sftp_lock(sftp) do
+        open(file_name, "r") do local_file
 
 
-    open(file_name, "r") do local_file
+            file = escapeuri(basename(file_name))
 
+            uri = resolvereference(sftp.uri, file)
 
-        file = escapeuri(basename(file_name))
+            output = Downloads.request(string(uri), input=local_file; downloader=sftp.downloader)
+        end
 
-        uri = resolvereference(sftp.uri, file)
-
-        output = Downloads.request(string(uri), input=local_file; downloader=sftp.downloader)
+        return nothing
     end
-
-    return nothing
 end
 
 
@@ -626,35 +663,35 @@ function download(
     sftp::SFTP,
     file_name::AbstractString,
     output=tempname(); downloadDir::Union{String,Nothing}=nothing)
+    return with_sftp_lock(sftp) do
+        if file_name == "." || file_name == ".."
+            return
+        end
 
+        if downloadDir != nothing
+            output = joinpath(abspath(downloadDir), file_name)
+        end
 
-    if file_name == "." || file_name == ".."
-        return
+        # Use escapepath (not escapeuri) to preserve '/' in multi-segment paths
+        uri = resolvereference(sftp.uri, escapepath(file_name))
+
+        # Override easy_hook to remove CURLOPT_DIRLISTONLY (set by reset_easy_hook for readdir)
+        sftp.downloader.easy_hook = (easy, info) -> begin
+            setStandardOptions(sftp, easy, info)
+        end
+
+        try
+
+            output = Downloads.download(string(uri), output; sftp.downloader)
+
+        catch e
+
+            rethrow()
+        finally
+            reset_easy_hook(sftp)
+        end
+        return output
     end
-
-    if downloadDir != nothing
-        output = joinpath(abspath(downloadDir), file_name)
-    end
-
-    # Use escapepath (not escapeuri) to preserve '/' in multi-segment paths
-    uri = resolvereference(sftp.uri, escapepath(file_name))
-
-    # Override easy_hook to remove CURLOPT_DIRLISTONLY (set by reset_easy_hook for readdir)
-    sftp.downloader.easy_hook = (easy, info) -> begin
-        setStandardOptions(sftp, easy, info)
-    end
-
-    try
-
-        output = Downloads.download(string(uri), output; sftp.downloader)
-
-    catch e
-
-        rethrow()
-    finally
-        reset_easy_hook(sftp)
-    end
-    return output
 end
 
 """
@@ -664,42 +701,44 @@ Reads the current directory. Returns a vector of Strings just like the regular r
 
 """
 function Base.readdir(sftp::SFTP, join::Bool=false, sort::Bool=true)
-    output = nothing
+    return with_sftp_lock(sftp) do
+        output = nothing
 
-    try
-        uriString = string(sftp.uri)
-        if !endswith(uriString, "/")
-            uriString = uriString * "/"
-            sftp.uri = URI(uriString)
+        try
+            uriString = string(sftp.uri)
+            if !endswith(uriString, "/")
+                uriString = uriString * "/"
+                sftp.uri = URI(uriString)
+            end
+
+            #println("URI String $uriString")
+
+            dir = sftp.uri.path
+
+
+            io = IOBuffer()
+
+            output = Downloads.download(uriString, io; sftp.downloader)
+
+
+            # Don't know why this is necessary
+            res = String(take!(io))
+            io2 = IOBuffer(res)
+            files = readlines(io2; keep=false)
+
+            files = filter(x -> x != "..", files)
+
+            files = filter(x -> x != ".", files)
+
+
+            sort && sort!(files)
+
+            join && return joinpath.(dir, files)
+
+            return files
+        catch e
+            rethrow()
         end
-
-        #println("URI String $uriString")
-
-        dir = sftp.uri.path
-
-
-        io = IOBuffer()
-
-        output = Downloads.download(uriString, io; sftp.downloader)
-
-
-        # Don't know why this is necessary
-        res = String(take!(io))
-        io2 = IOBuffer(res)
-        files = readlines(io2; keep=false)
-
-        files = filter(x -> x != "..", files)
-
-        files = filter(x -> x != ".", files)
-
-
-        sort && sort!(files)
-
-        join && return joinpath.(dir, files)
-
-        return files
-    catch e
-        rethrow()
     end
 
 end
@@ -711,28 +750,29 @@ end
 
 """
 function Base.cd(sftp::SFTP, dir::AbstractString)
+    return with_sftp_lock(sftp) do
+        oldUrl = sftp.uri
 
-    oldUrl = sftp.uri
+        # If we fail, set back to the old url
+        try
 
-    # If we fail, set back to the old url
-    try
+            if !isdirpath(dir)
+                dir = dir * "/"
+            end
 
-        if !isdirpath(dir)
-            dir = dir * "/"
+            newUrl = resolvereference(oldUrl, sftpescapepath(dir))
+
+            #show(newUrl)
+
+            sftp.uri = newUrl
+            #show(sftp.uri)
+            readdir(sftp)
+        catch e
+            sftp.uri = oldUrl
+            rethrow()
         end
-
-        newUrl = resolvereference(oldUrl, sftpescapepath(dir))
-
-        #show(newUrl)
-
-        sftp.uri = newUrl
-        #show(sftp.uri)
-        readdir(sftp)
-    catch e
-        sftp.uri = oldUrl
-        rethrow()
+        return nothing
     end
-    return nothing
 end
 
 


### PR DESCRIPTION
## Context / conversation summary
When downloading files using `SFTPClient.download` with multi-segment remote paths (e.g., `path/to/subdir/file.dat`), the downloaded files were always ~3–4 KB (e.g., ~3480 bytes) instead of the expected file content (which should be hundreds of KB or larger).

Inspecting these downloaded files revealed they contained **a newline-separated list of filenames** rather than the actual file content. This indicated the library was accidentally downloading a **directory listing** instead of the requested file.

We then traced the behavior to `download` in [SFTPClient.jl/src/SFTPImpl.jl](SFTPClient.jl/src/SFTPImpl.jl), where:
- the downloader’s `easy_hook` still had `CURLOPT_DIRLISTONLY=1` enabled (a setting intended for `readdir`), and
- path escaping used `escapeuri`, which percent-encodes `/` and breaks multi-segment remote paths.

## Root cause
Two independent issues in `SFTPClient.download` produced the “4KB downloads” symptom:

1. **`CURLOPT_DIRLISTONLY` leaking into `download`**
   - `reset_easy_hook(sftp)` sets the downloader hook to include `CURLOPT_DIRLISTONLY=1`.
   - `download` reused the same downloader without overriding this option, so libcurl performed a **directory listing** operation and saved that output into the destination file.

2. **Incorrect escaping for remote paths (`escapeuri` vs `escapepath`)**
   - `download` used `escapeuri(file_name)`, which encodes `/` → `%2F`.
   - For multi-segment paths like `dir/subdir/file.dat`, this turns the path into a single URL segment and can misaddress the remote resource.

Either issue is problematic; together they reliably cause invalid downloads.

## Changes in this PR
**File:** [SFTPClient.jl/src/SFTPImpl.jl](SFTPClient.jl/src/SFTPImpl.jl)

- Update `download` to use `escapepath(file_name)` instead of `escapeuri(file_name)`.
- Temporarily override `sftp.downloader.easy_hook` inside `download` so it calls `setStandardOptions` **without** setting `CURLOPT_DIRLISTONLY`.
- Ensure `reset_easy_hook(sftp)` is called in a `finally` block to restore the original behavior for subsequent directory operations (e.g., `readdir`).
- Add a per-instance `ReentrantLock` (`op_lock`) to `SFTP`.
- Add a compatibility 9-argument outer constructor for `SFTP(...)` that initializes `op_lock`, so existing constructor call sites remain unchanged.
- Serialize stateful operations via `with_sftp_lock(...)` for methods that read/mutate shared `sftp.uri` and/or `sftp.downloader.easy_hook`:
   - `download`
   - `readdir`
   - `cd`
   - `sftpstat`
   - `ftp_command` (and therefore `rm`, `rmdir`, `mkdir`, `mv`)
   - `upload`

This keeps the existing `readdir` behavior unchanged while making `download` correct.

## How to reproduce (before) / verify (after)
### Repro (before)
- Call `SFTPClient.download(sftp, "dir/subdir/file.dat"; downloadDir=...)`  with a multi-segment path
- Observe the output file is ~3–4 KB and contains a list of filenames.

### Verification (after)
- Download the same path.
- Observe the output file is **much larger** (actual file size, e.g., **180+ KB**) and contains the actual file content instead of a directory listing.

## Notes / tradeoffs
- The current library design still mutates `sftp.downloader.easy_hook` to switch operation modes, but this PR now guards these state transitions with a per-instance lock.
- Concurrency model after this change:
   - Operations on the **same** `SFTP` instance are serialized (thread-safe with respect to `uri`/`easy_hook` races).
   - Operations on **different** `SFTP` instances can proceed concurrently.
- This is a minimal-API-disruption fix; a future redesign could use per-operation downloader state to avoid mutable global hook state entirely.
